### PR TITLE
Check changes to `README.md` on `main`

### DIFF
--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - main
   schedule:
-    - cron: "0 8 * * 1-5"
+    - cron: "0 9 * * 1-5"
 
 jobs:
   markscribe:
@@ -19,8 +19,8 @@ jobs:
       - name: Find the last commit to README
         id: commit-count
         run: >-
-          echo count=$(git log --oneline --since=midnight ./README.md | wc -l)
-          >> $GITHUB_OUTPUT
+          echo count=$(git log --oneline --since=midnight main -- ./README.md
+          | wc -l) >> $GITHUB_OUTPUT
 
       - name: Autogenerate README
         # yamllint disable-line rule:line-length
@@ -32,7 +32,7 @@ jobs:
           writeTo: ./README.md
 
       - name: Push README to main
-        # if: ${{ steps.commit-count.outputs.count == 0 }}
+        if: ${{ steps.commit-count.outputs.count == 0 }}
         # yamllint disable-line rule:line-length
         uses: stefanzweifel/git-auto-commit-action@8756aa072ef5b4a080af5dc8fef36c5d586e521d # v5
         env:


### PR DESCRIPTION
For some reason for the first run today was skipped. These two were forced by commenting out the `if`
![image](https://github.com/paddyroddy/paddyroddy/assets/15052188/2e4782a9-0ac5-46d5-a902-bec5c338a382)

Now checking against `main` @milanmlft